### PR TITLE
Fix errors in validity directory, and make up to date with current version

### DIFF
--- a/ADL2-reference/features/specialisation/openEHR-EHR-OBSERVATION.redefine_occurrences.v1.0.0.adls
+++ b/ADL2-reference/features/specialisation/openEHR-EHR-OBSERVATION.redefine_occurrences.v1.0.0.adls
@@ -39,7 +39,7 @@ definition
 		}
 	}
 
-ontology
+terminology
 	term_definitions = <
 		["en"] = <
 			["id1.1"] = <

--- a/ADL2-reference/validity/annotations/openEHR-EHR-COMPOSITION.VRANP_annotations_wrong_rm_path.v1.0.0.adls
+++ b/ADL2-reference/validity/annotations/openEHR-EHR-COMPOSITION.VRANP_annotations_wrong_rm_path.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-COMPOSITION.VRANP_annotations_wrong_rm_path.v1.0.0
 
 language

--- a/ADL2-reference/validity/annotations/openEHR-EHR-EVALUATION.VRANP_annotations_wrong_path.v1.0.0.adls
+++ b/ADL2-reference/validity/annotations/openEHR-EHR-EVALUATION.VRANP_annotations_wrong_path.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-EVALUATION.VRANP_annotations_wrong_path.v1.0.0
 
 language

--- a/ADL2-reference/validity/basics/openEHR-DEMOGRAPHIC-ROLE.whitespace.v1.0.0.adls
+++ b/ADL2-reference/validity/basics/openEHR-DEMOGRAPHIC-ROLE.whitespace.v1.0.0.adls
@@ -1,4 +1,4 @@
-﻿archetype (adl_version=2.0.5; rm_release=1.0.2)
+﻿archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-DEMOGRAPHIC-ROLE.whitespace.v1.0.0
 
 language

--- a/ADL2-reference/validity/basics/openEHR-EHR-OBSERVATION.FAIL_dadl_spurious_delimiter.v1.0.0.adls
+++ b/ADL2-reference/validity/basics/openEHR-EHR-OBSERVATION.FAIL_dadl_spurious_delimiter.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-OBSERVATION.FAIL_dadl_spurious_delimiter.v1.0.0
 
 language

--- a/ADL2-reference/validity/basics/openEHR-EHR-OBSERVATION.VRDLA_inconsistent_lang_codes.v1.0.0.adls
+++ b/ADL2-reference/validity/basics/openEHR-EHR-OBSERVATION.VRDLA_inconsistent_lang_codes.v1.0.0.adls
@@ -41,7 +41,7 @@ definition
 			HISTORY[id2] matches {	-- history
 				events cardinality matches {1..*; unordered} matches {
 					EVENT[id7] occurrences matches {0..*} matches {	-- any event
-						data matches {*}
+						data
 					}
 				}
 			}

--- a/ADL2-reference/validity/basics/openEHR-TEST_PKG-ENTRY.FAIL_archetype_id_empty.v1.adls
+++ b/ADL2-reference/validity/basics/openEHR-TEST_PKG-ENTRY.FAIL_archetype_id_empty.v1.adls
@@ -1,7 +1,5 @@
-archetype (adl_version=1.5)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 
-concept
-	[at0000]
 language
 	original_language = <[ISO_639-1::en]>
 description
@@ -22,16 +20,14 @@ description
 	lifecycle_state = <"draft">
 
 definition
-	ENTRY[at0000] matches {*}
+	ENTRY[id1]
 
-ontology
+terminology
 	term_definitions = <
 		["en"] = <
-			items = <
-				["at0000"] = <
-					text = <"">
-					description = <"">
-				>
-			>
+            ["id1"] = <
+                text = <" ">
+                description = <" ">
+            >
 		>
 	>

--- a/ADL2-reference/validity/basics/openEHR-TEST_PKG-ENTRY.FAIL_archetype_id_missing.v1.adls
+++ b/ADL2-reference/validity/basics/openEHR-TEST_PKG-ENTRY.FAIL_archetype_id_missing.v1.adls
@@ -1,5 +1,3 @@
-concept
-	[at0000]
 language
 	original_language = <[ISO_639-1::en]>
 description
@@ -20,16 +18,14 @@ description
 	lifecycle_state = <"draft">
 
 definition
-	ENTRY[at0000] matches {*}
+	ENTRY[id1]
 
-ontology
+terminology
 	term_definitions = <
 		["en"] = <
-			items = <
-				["at0000"] = <
-					text = <"">
-					description = <"">
-				>
-			>
+            ["id1"] = <
+                text = <"">
+                description = <"">
+            >
 		>
 	>

--- a/ADL2-reference/validity/basics/openEHR-TEST_PKG-ENTRY.FAIL_definition_empty.v1.0.0.adls
+++ b/ADL2-reference/validity/basics/openEHR-TEST_PKG-ENTRY.FAIL_definition_empty.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-TEST_PKG-ENTRY.FAIL_definition_empty.v1
 
 language

--- a/ADL2-reference/validity/basics/openEHR-TEST_PKG-ENTRY.FAIL_definition_missing.v1.0.0.adls
+++ b/ADL2-reference/validity/basics/openEHR-TEST_PKG-ENTRY.FAIL_definition_missing.v1.0.0.adls
@@ -1,5 +1,5 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
-	openEHR-TEST_PKG-ENTRY.FAIL_definition_missing.v1
+archetype (adl_version=2.0.7; rm_release=1.0.2)
+	openEHR-TEST_PKG-ENTRY.FAIL_definition_missing.v1.0.0
 
 language
 	original_language = <[ISO_639-1::en]>

--- a/ADL2-reference/validity/basics/openEHR-TEST_PKG-ENTRY.FAIL_terminology_extra_end_mark.v1.0.0.adls
+++ b/ADL2-reference/validity/basics/openEHR-TEST_PKG-ENTRY.FAIL_terminology_extra_end_mark.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-TEST_PKG-ENTRY.FAIL_terminology_extra_end_mark.v1.0.0
 
 language

--- a/ADL2-reference/validity/basics/openEHR-TEST_PKG-ENTRY.FAIL_terminology_missing.v1.0.0.adls
+++ b/ADL2-reference/validity/basics/openEHR-TEST_PKG-ENTRY.FAIL_terminology_missing.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-TEST_PKG-ENTRY.FAIL_terminology_missing.v1.0.0
 
 language

--- a/ADL2-reference/validity/basics/openEHR-TEST_PKG-ENTRY.SADF_definition_after_terminology.v1.0.0.adls
+++ b/ADL2-reference/validity/basics/openEHR-TEST_PKG-ENTRY.SADF_definition_after_terminology.v1.0.0.adls
@@ -1,5 +1,5 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
-	openEHR-TEST_PKG-ENTRY.SADF_definition_after_terminology.v1
+archetype (adl_version=2.0.6; rm_release=1.0.2)
+	openEHR-TEST_PKG-ENTRY.SADF_definition_after_terminology.v1.0.0
 
 language
 	original_language = <[ISO_639-1::en]>
@@ -31,4 +31,4 @@ terminology
 	>
 
 definition
-	ENTRY[id1] matches {*}
+	ENTRY[id1]

--- a/ADL2-reference/validity/basics/openEHR-TEST_PKG-ENTRY.SCAS_attribute_empty.v1.0.0.adls
+++ b/ADL2-reference/validity/basics/openEHR-TEST_PKG-ENTRY.SCAS_attribute_empty.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7 rm_release=1.0.2)
 	openEHR-TEST_PKG-ENTRY.SCAS_attribute_empty.v1.0.0
 
 language

--- a/ADL2-reference/validity/basics/openEHR-TEST_PKG-ENTRY.SCOAT_object_empty.v1.0.0.adls
+++ b/ADL2-reference/validity/basics/openEHR-TEST_PKG-ENTRY.SCOAT_object_empty.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-TEST_PKG-ENTRY.SCOAT_object_empty.v1.0.0
 
 language
@@ -11,7 +11,7 @@ description
 	details = <
 		["en"] = <
 			language = <[ISO_639-1::en]>
-			purpose = <"Test SCOAT syntax validity check, triggered by object constraint that is empty (should be either '*' or something specific)">
+			purpose = <"Test SCOAT syntax validity check, triggered by object constraint that is empty (should be something specific or left out)">
 			copyright = <"copyright (c) 2008 The openEHR Foundation">
 		>
 	>
@@ -31,8 +31,8 @@ terminology
 	term_definitions = <
 		["en"] = <
 			["id1"] = <
-				text = <"">
-				description = <"">
+				text = <" ">
+				description = <" ">
 			>
 		>
 	>

--- a/ADL2-reference/validity/basics/openEHR-TEST_PKG-ENTRY.VARCN_illegal_concept_code.v1.0.0.adls
+++ b/ADL2-reference/validity/basics/openEHR-TEST_PKG-ENTRY.VARCN_illegal_concept_code.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-TEST_PKG-ENTRY.VARCN_illegal_concept_code.v1.0.0
 
 language
@@ -21,7 +21,7 @@ description
 	lifecycle_state = <"draft">
 
 definition
-	ENTRY[id2] matches {*}
+	ENTRY[id2]
 
 terminology
 	term_definitions = <

--- a/ADL2-reference/validity/basics/openEHR-TEST_PKG-ENTRY.VCOID_container_attribute_children_no_node_identifiers.v1.0.0.adls
+++ b/ADL2-reference/validity/basics/openEHR-TEST_PKG-ENTRY.VCOID_container_attribute_children_no_node_identifiers.v1.0.0.adls
@@ -1,5 +1,5 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
-	openEHR-TEST_PKG-ENTRY.VCOID_container_attribute_children_no_node_identifiers.v1
+archetype (adl_version=2.0.7; rm_release=1.0.2)
+	openEHR-TEST_PKG-ENTRY.VCOID_container_attribute_children_no_node_identifiers.v1.0.0
 
 language
 	original_language = <[ISO_639-1::en]>
@@ -10,7 +10,7 @@ description
 	details = <
 		["en"] = <
 			language = <[ISO_639-1::en]>
-			purpose = <"Test VCOID validity check, triggered when child objects of a container attribute don't have node identifiers.">
+			purpose = <"Test VCOID validity check, triggered when any object nodes don't have node identifiers">
 			keywords = <"ADL", "validation", "test">
 			copyright = <"copyright (c) 2008 The openEHR Foundation">
 		>
@@ -25,18 +25,18 @@ definition
 		element_attr_2 cardinality matches {2} matches {
 			ELEMENT matches {
 				value matches {
-					DV_TEXT matches {*}
+					DV_TEXT
 				}
 			}
 			ELEMENT matches {
 				value matches {
-					DV_TEXT matches {*}
+					DV_TEXT
 				}
 			}
 		}
 	}
 
-ontology
+terminology
 	term_definitions = <
 		["en"] = <
 			["id1"] = <

--- a/ADL2-reference/validity/basics/openEHR-TEST_PKG-ENTRY.VCOID_missing_ids_on_alternative_children.v1.0.0.adls
+++ b/ADL2-reference/validity/basics/openEHR-TEST_PKG-ENTRY.VCOID_missing_ids_on_alternative_children.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.6; rm_release=1.0.2)
 	openEHR-TEST_PKG-ENTRY.VCOID_missing_ids_on_alternative_children.v1.0.0
 
 language

--- a/ADL2-reference/validity/basics/openEHR-TEST_PKG-ENTRY.VCOID_objects_with_no_node_identifiers.v1.0.0.adls
+++ b/ADL2-reference/validity/basics/openEHR-TEST_PKG-ENTRY.VCOID_objects_with_no_node_identifiers.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=2.0.5; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-TEST_PKG-ENTRY.VCOID_objects_with_no_node_identifiers.v1.0.0
 
 language

--- a/ADL2-reference/validity/basics/openehr-TEST_PKG-WHOLE.VCOID_missing_root_node_id.v1.0.0.adls
+++ b/ADL2-reference/validity/basics/openehr-TEST_PKG-WHOLE.VCOID_missing_root_node_id.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=2.0.5; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openehr-TEST_PKG-WHOLE.VCOID_missing_root_node_id.v1.0.0
 
 language
@@ -22,17 +22,14 @@ description
 	>
 
 definition
-	WHOLE matches {*}
-	}
+	WHOLE
 
 terminology
 	term_definitions = <
 		["en"] = <
-			items = <
-				["at1"] = <
-					description = <"test entry">
-					text = <"test entry">
-				>
-			>
+            ["at1"] = <
+                description = <"test entry">
+                text = <"test entry">
+            >
 		>
 	>

--- a/ADL2-reference/validity/consistency/openEHR-TEST_PKG-ENTRY.VACDF_ac_code_in_definition_not_in_terminology.v1.0.0.adls
+++ b/ADL2-reference/validity/consistency/openEHR-TEST_PKG-ENTRY.VACDF_ac_code_in_definition_not_in_terminology.v1.0.0.adls
@@ -1,5 +1,5 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
-	openEHR-TEST_PKG-ENTRY.VACDF_ac_code_in_definition_not_in_terminology.v1
+archetype (adl_version=2.0.7; rm_release=1.0.2)
+	openEHR-TEST_PKG-ENTRY.VACDF_ac_code_in_definition_not_in_terminology.v1.0.0
 
 language
 	original_language = <[ISO_639-1::en]>

--- a/ADL2-reference/validity/consistency/openEHR-TEST_PKG-ENTRY.VATDF_at_code_in_ordinal_not_in_terminology.v1.0.0.adls
+++ b/ADL2-reference/validity/consistency/openEHR-TEST_PKG-ENTRY.VATDF_at_code_in_ordinal_not_in_terminology.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-TEST_PKG-ENTRY.VATDF_at_code_in_ordinal_not_in_terminology.v1.0.0
 
 language

--- a/ADL2-reference/validity/consistency/openEHR-TEST_PKG-ENTRY.VATID_concept_code_not_in_terminology.v1.0.0.adls
+++ b/ADL2-reference/validity/consistency/openEHR-TEST_PKG-ENTRY.VATID_concept_code_not_in_terminology.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-TEST_PKG-ENTRY.VATID_concept_code_not_in_terminology.v1.0.0
 
 language
@@ -27,10 +27,9 @@ definition
 terminology
 	term_definitions = <
 		["en"] = <
-                          ["id2"] = <
-                                   text = <"">
-                                   description = <"">
-                          >
+                  ["id2"] = <
+                           text = <"">
+                           description = <"">
                   >
-		>
-	>
+          >
+    >

--- a/ADL2-reference/validity/consistency/openEHR-TEST_PKG-ENTRY.VATID_id_code_in_node_not_in_terminology.v1.0.0.adls
+++ b/ADL2-reference/validity/consistency/openEHR-TEST_PKG-ENTRY.VATID_id_code_in_node_not_in_terminology.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-TEST_PKG-ENTRY.VATID_id_code_in_node_not_in_terminology.v1.0.0
 
 language

--- a/ADL2-reference/validity/consistency/openEHR-TEST_PKG-ENTRY.VOTM_terminology_term_definitions_empty.v1.0.0.adls
+++ b/ADL2-reference/validity/consistency/openEHR-TEST_PKG-ENTRY.VOTM_terminology_term_definitions_empty.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-TEST_PKG-ENTRY.VOTM_terminology_term_definitions_empty.v1.0.0
 
 language

--- a/ADL2-reference/validity/consistency/openEHR-TEST_PKG-ENTRY.VOTM_terminology_term_definitions_of_original_language_missing.v1.0.0.adls
+++ b/ADL2-reference/validity/consistency/openEHR-TEST_PKG-ENTRY.VOTM_terminology_term_definitions_of_original_language_missing.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-TEST_PKG-ENTRY.VOTM_terminology_term_definitions_of_original_language_missing.v1.0.0
 
 language
@@ -22,7 +22,7 @@ description
 	lifecycle_state = <"unstable">
 
 definition
-	ENTRY[id1] matches {*}
+	ENTRY[id1]
 
 terminology
 	term_definitions = <

--- a/ADL2-reference/validity/consistency/openEHR-TEST_PKG-ENTRY.VOTM_terminology_term_definitions_of_other_language_missing.v1.0.0.adls
+++ b/ADL2-reference/validity/consistency/openEHR-TEST_PKG-ENTRY.VOTM_terminology_term_definitions_of_other_language_missing.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-TEST_PKG-ENTRY.VOTM_terminology_term_definitions_of_other_language_missing.v1.0.0
 
 language

--- a/ADL2-reference/validity/consistency/openEHR-TEST_PKG-ENTRY.VTLC_ac_code_not_in_all_languages.v1.0.0.adls
+++ b/ADL2-reference/validity/consistency/openEHR-TEST_PKG-ENTRY.VTLC_ac_code_not_in_all_languages.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-TEST_PKG-ENTRY.VTLC_ac_code_not_in_all_languages.v1.0.0
 
 language

--- a/ADL2-reference/validity/consistency/openEHR-TEST_PKG-ENTRY.VTLC_at_code_in_coded_term_not_in_all_languages.v1.0.0.adls
+++ b/ADL2-reference/validity/consistency/openEHR-TEST_PKG-ENTRY.VTLC_at_code_in_coded_term_not_in_all_languages.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-TEST_PKG-ENTRY.VTLC_at_code_in_coded_term_not_in_all_languages.v1.0.0
 
 language

--- a/ADL2-reference/validity/consistency/openEHR-TEST_PKG-ENTRY.VTLC_at_code_in_ordinal_not_in_all_languages.v1.0.0.adls
+++ b/ADL2-reference/validity/consistency/openEHR-TEST_PKG-ENTRY.VTLC_at_code_in_ordinal_not_in_all_languages.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-TEST_PKG-ENTRY.VTLC_at_code_in_ordinal_not_in_all_languages.v1.0.0
 
 language

--- a/ADL2-reference/validity/consistency/openEHR-TEST_PKG-ENTRY.VTLC_missing_constraint_definitions_in_one_language.v1.0.0.adls
+++ b/ADL2-reference/validity/consistency/openEHR-TEST_PKG-ENTRY.VTLC_missing_constraint_definitions_in_one_language.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-TEST_PKG-ENTRY.VTLC_missing_constraint_definitions_in_one_language.v1.0.0
 
 language

--- a/ADL2-reference/validity/consistency/openEHR-TEST_PKG-ENTRY.VTLC_node_id_not_in_all_languages.v1.0.0.adls
+++ b/ADL2-reference/validity/consistency/openEHR-TEST_PKG-ENTRY.VTLC_node_id_not_in_all_languages.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-TEST_PKG-ENTRY.VTLC_node_id_not_in_all_languages.v1.0.0
 
 language

--- a/ADL2-reference/validity/consistency/openEHR-TEST_PKG-ENTRY.VTVSMD_at_code_in_coded_term_not_in_terminology.v1.0.0.adls
+++ b/ADL2-reference/validity/consistency/openEHR-TEST_PKG-ENTRY.VTVSMD_at_code_in_coded_term_not_in_terminology.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-TEST_PKG-ENTRY.VTVSMD_at_code_in_coded_term_not_in_terminology.v1.0.0
 
 language

--- a/ADL2-reference/validity/domain_types/openEHR-TEST_PKG-ENTRY.VTVSUQ_at_code_duplicated_in_ordinal.v1.0.0.adls
+++ b/ADL2-reference/validity/domain_types/openEHR-TEST_PKG-ENTRY.VTVSUQ_at_code_duplicated_in_ordinal.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=2.0.5; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-TEST_PKG-ENTRY.VTVSUQ_at_code_duplicated_in_ordinal.v1.0.0
 
 language

--- a/ADL2-reference/validity/paths/openEHR-TEST_PKG-CAR.VCOID_uncoded_interior_nodes.v1.0.0.adls
+++ b/ADL2-reference/validity/paths/openEHR-TEST_PKG-CAR.VCOID_uncoded_interior_nodes.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-TEST_PKG-CAR.VCOID_uncoded_interior_nodes.v1.0.0
 
 language

--- a/ADL2-reference/validity/paths/openEHR-TEST_PKG-CAR.VUNP_internal_ref_bad_path.v1.0.0.adls
+++ b/ADL2-reference/validity/paths/openEHR-TEST_PKG-CAR.VUNP_internal_ref_bad_path.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=2.0.5; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-TEST_PKG-CAR.VUNP_internal_ref_bad_path.v1.0.0
 
 language

--- a/ADL2-reference/validity/rm_checking/openEHR-DEMOGRAPHIC-ORGANISATION.VCAEX_rm_non_conformant_existence.v1.0.0.adls
+++ b/ADL2-reference/validity/rm_checking/openEHR-DEMOGRAPHIC-ORGANISATION.VCAEX_rm_non_conformant_existence.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-DEMOGRAPHIC-ORGANISATION.VCAEX_rm_non_conformant_existence.v1.0.0
 
 language

--- a/ADL2-reference/validity/rm_checking/openEHR-DEMOGRAPHIC-ORGANISATION.rm_same_cardinality.v1.0.0.adls
+++ b/ADL2-reference/validity/rm_checking/openEHR-DEMOGRAPHIC-ORGANISATION.rm_same_cardinality.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=2.0.5; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-DEMOGRAPHIC-ORGANISATION.rm_same_cardinality.v1.0.0
 
 language

--- a/ADL2-reference/validity/rm_checking/openEHR-DEMOGRAPHIC-ORGANISATION.rm_same_existence.v1.0.0.adls
+++ b/ADL2-reference/validity/rm_checking/openEHR-DEMOGRAPHIC-ORGANISATION.rm_same_existence.v1.0.0.adls
@@ -1,4 +1,4 @@
-﻿archetype (adl_version=2.0.5; rm_release=1.0.2)
+﻿archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-DEMOGRAPHIC-ORGANISATION.rm_same_existence.v1.0.0
 
 language

--- a/ADL2-reference/validity/rm_checking/openEHR-EHR-EVALUATION.VCARM_rm_non_existent_attribute.v1.0.0.adls
+++ b/ADL2-reference/validity/rm_checking/openEHR-EHR-EVALUATION.VCARM_rm_non_existent_attribute.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-EVALUATION.VCARM_rm_non_existent_attribute.v1.0.0
 
 language

--- a/ADL2-reference/validity/rm_checking/openEHR-EHR-EVALUATION.VCORM_rm_non_existent_type.v1.0.0.adls
+++ b/ADL2-reference/validity/rm_checking/openEHR-EHR-EVALUATION.VCORM_rm_non_existent_type.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-EVALUATION.VCORM_rm_non_existent_type.v1.0.0
 
 language

--- a/ADL2-reference/validity/rm_checking/openEHR-EHR-EVALUATION.VSAM_rm_cardinality_on_single_attr.v1.0.0.adls
+++ b/ADL2-reference/validity/rm_checking/openEHR-EHR-EVALUATION.VSAM_rm_cardinality_on_single_attr.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-EVALUATION.VSAM_rm_cardinality_on_single_attr.v1.0.0
 
 language
@@ -25,7 +25,7 @@ description
 
 definition
 	EVALUATION[id1] matches {	
-		protocol cardinality matches {1..*} matches {*}
+		protocol cardinality matches {1..*}
 	}
 
 terminology

--- a/ADL2-reference/validity/rm_checking/openEHR-EHR-EVALUATION.VSAM_rm_wrong_multiple_attr.v1.0.0.adls
+++ b/ADL2-reference/validity/rm_checking/openEHR-EHR-EVALUATION.VSAM_rm_wrong_multiple_attr.v1.0.0.adls
@@ -1,5 +1,5 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
-	openEHR-EHR-EVALUATION.VSAM_rm_wrong_multiple_attr.v1
+archetype (adl_version=2.0.7; rm_release=1.0.2)
+	openEHR-EHR-EVALUATION.VSAM_rm_wrong_multiple_attr.v1.0.0
 
 language
 	original_language = <[ISO_639-1::en]>

--- a/ADL2-reference/validity/rm_checking/openEHR-EHR-OBSERVATION.VCORMT_rm_non_conforming_type1.v1.0.0.adls
+++ b/ADL2-reference/validity/rm_checking/openEHR-EHR-OBSERVATION.VCORMT_rm_non_conforming_type1.v1.0.0.adls
@@ -1,5 +1,5 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
-	openEHR-EHR-OBSERVATION.VCORMT_rm_non_conforming_type1.v1
+archetype (adl_version=2.0.7; rm_release=1.0.2)
+	openEHR-EHR-OBSERVATION.VCORMT_rm_non_conforming_type1.v1.0.0
 
 language
 	original_language = <[ISO_639-1::en]>
@@ -29,7 +29,7 @@ definition
 				events cardinality matches {1..*; unordered} matches {
 					EVENT<CLUSTER> [id3] occurrences matches {0..*} matches {
 						data matches {
-							ITEM_LIST[id4] matches {*}
+							ITEM_LIST[id4]
 						}
 					}
 				}

--- a/ADL2-reference/validity/rm_checking/openEHR-EHR-OBSERVATION.VCORMT_rm_non_conforming_type2.v1.0.0.adls
+++ b/ADL2-reference/validity/rm_checking/openEHR-EHR-OBSERVATION.VCORMT_rm_non_conforming_type2.v1.0.0.adls
@@ -1,5 +1,5 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
-	openEHR-EHR-OBSERVATION.VCORMT_rm_non_conforming_type2.v1
+archetype (adl_version=2.0.7; rm_release=1.0.2)
+	openEHR-EHR-OBSERVATION.VCORMT_rm_non_conforming_type2.v1.0.0
 
 language
 	original_language = <[ISO_639-1::en]>
@@ -27,7 +27,7 @@ definition
 		data matches {
 			HISTORY<ITEM_LIST>[id2] matches {	
 				events cardinality matches {1..*; unordered} matches {
-					CLUSTER[id3] occurrences matches {0..*} matches {*}
+					CLUSTER[id3] occurrences matches {0..*}
 				}
 			}
 		}

--- a/ADL2-reference/validity/rm_checking/openEHR-TEST_PKG-ENTRY_WRONG.rm_type_wrong.v1.0.0.adls
+++ b/ADL2-reference/validity/rm_checking/openEHR-TEST_PKG-ENTRY_WRONG.rm_type_wrong.v1.0.0.adls
@@ -1,8 +1,6 @@
-archetype (adl_version=1.5)
-	openEHR-TEST_PKG-ENTRY_WRONG.rm_type_wrong.v1
+archetype (adl_version=2.0.7; rm_release=1.0.2)
+	openEHR-TEST_PKG-ENTRY_WRONG.rm_type_wrong.v1.0.0
 
-concept
-	[at0000]
 language
 	original_language = <[ISO_639-1::en]>
 description
@@ -18,21 +16,19 @@ description
 		>
 	>
 	other_details = <
-		["regression"] = <"PASS">
+		["regression"] = <"VARDT">
 	>
 	lifecycle_state = <"draft">
 
 definition
-	ENTRY[at0000] matches {*}
+	ENTRY[id1]
 
-ontology
+terminology
 	term_definitions = <
 		["en"] = <
-			items = <
-				["at0000"] = <
-					text = <"">
-					description = <"">
-				>
-			>
+            ["id1"] = <
+					text = <" ">
+					description = <" ">
+            >
 		>
 	>

--- a/ADL2-reference/validity/rm_checking/openEHR-TEST_PKG-entry.VARDT_rm_type_wrong_capitalisation.v1.0.0.adls
+++ b/ADL2-reference/validity/rm_checking/openEHR-TEST_PKG-entry.VARDT_rm_type_wrong_capitalisation.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-TEST_PKG-entry.VARDT_rm_type_wrong_capitalisation.v1.0.0
 
 language

--- a/ADL2-reference/validity/slots/openEHR-EHR-SECTION.VARXID_filler_id_not_valid.v1.0.0.adls
+++ b/ADL2-reference/validity/slots/openEHR-EHR-SECTION.VARXID_filler_id_not_valid.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-SECTION.VARXID_filler_id_not_valid.v1.0.0
 
 specialize

--- a/ADL2-reference/validity/slots/openEHR-EHR-SECTION.VARXR_slot_id_match_but_not_found.v1.0.0.adls
+++ b/ADL2-reference/validity/slots/openEHR-EHR-SECTION.VARXR_slot_id_match_but_not_found.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-SECTION.VARXR_slot_id_match_but_not_found.v1.0.0
 
 specialise

--- a/ADL2-reference/validity/slots/openEHR-EHR-SECTION.VARXS_slot_id_mismatch.v1.0.0.adls
+++ b/ADL2-reference/validity/slots/openEHR-EHR-SECTION.VARXS_slot_id_mismatch.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-SECTION.VARXS_slot_id_mismatch.v1.0.0
 
 specialize

--- a/ADL2-reference/validity/slots/openEHR-EHR-SECTION.VDSEV_slot_include_any_exclude_any.v1.0.0.adls
+++ b/ADL2-reference/validity/slots/openEHR-EHR-SECTION.VDSEV_slot_include_any_exclude_any.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-SECTION.VDSEV_slot_include_any_exclude_any.v1.0.0
 
 language

--- a/ADL2-reference/validity/slots/openEHR-EHR-SECTION.VDSEV_slot_include_not_any_exclude_not_any.v1.0.0.adls
+++ b/ADL2-reference/validity/slots/openEHR-EHR-SECTION.VDSEV_slot_include_not_any_exclude_not_any.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-SECTION.VDSEV_slot_include_not_any_exclude_not_any.v1.0.0
 
 language

--- a/ADL2-reference/validity/slots/openEHR-EHR-SECTION.VDSSID_slot_redefine_bad_id.v1.0.0.adls
+++ b/ADL2-reference/validity/slots/openEHR-EHR-SECTION.VDSSID_slot_redefine_bad_id.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-SECTION.VDSSID_slot_redefine_bad_id.v1.0.0
 
 specialise

--- a/ADL2-reference/validity/slots/openEHR-EHR-SECTION.slot_parent.v1.0.0.adls
+++ b/ADL2-reference/validity/slots/openEHR-EHR-SECTION.slot_parent.v1.0.0.adls
@@ -1,4 +1,4 @@
-﻿archetype (adl_version=2.0.5; rm_release=1.0.2)
+﻿archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-SECTION.slot_parent.v1.0.0
 
 language

--- a/ADL2-reference/validity/specialisation/openEHR-EHR-CLUSTER.address-VSSM_invalid_order_node_id.v1.0.0.adls
+++ b/ADL2-reference/validity/specialisation/openEHR-EHR-CLUSTER.address-VSSM_invalid_order_node_id.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-CLUSTER.address-VSSM_invalid_order_node_id.v1.0.0
 
 specialize

--- a/ADL2-reference/validity/specialisation/openEHR-EHR-CLUSTER.address.v1.0.0.adls
+++ b/ADL2-reference/validity/specialisation/openEHR-EHR-CLUSTER.address.v1.0.0.adls
@@ -1,4 +1,4 @@
-﻿archetype (adl_version=2.0.5; rm_release=1.0.2)
+﻿archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-CLUSTER.address.v1.0.0
 
 language

--- a/ADL2-reference/validity/specialisation/openEHR-EHR-EVALUATION.spec_test_eval1-no_change.v1.0.0.adls
+++ b/ADL2-reference/validity/specialisation/openEHR-EHR-EVALUATION.spec_test_eval1-no_change.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-EVALUATION.spec_test_eval1-no_change.v1.0.0
 
 specialise

--- a/ADL2-reference/validity/specialisation/openEHR-EHR-EVALUATION.spec_test_eval1.v1.0.0.adls
+++ b/ADL2-reference/validity/specialisation/openEHR-EHR-EVALUATION.spec_test_eval1.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=2.0.5; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-EVALUATION.spec_test_eval1.v1.0.0
 
 language

--- a/ADL2-reference/validity/specialisation/openEHR-EHR-OBSERVATION.VACSD_wrong_spec_level.v1.0.0.adls
+++ b/ADL2-reference/validity/specialisation/openEHR-EHR-OBSERVATION.VACSD_wrong_spec_level.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-OBSERVATION.VACSD_wrong_spec_level.v1.0.0
 
 specialize

--- a/ADL2-reference/validity/specialisation/openEHR-EHR-OBSERVATION.VCORMT_illegal_redef_of_ac_code_node.v1.0.0.adls
+++ b/ADL2-reference/validity/specialisation/openEHR-EHR-OBSERVATION.VCORMT_illegal_redef_of_ac_code_node.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-OBSERVATION.VCORMT_illegal_redef_of_ac_code_node.v1.0.0
 
 specialize

--- a/ADL2-reference/validity/specialisation/openEHR-EHR-OBSERVATION.VCORMT_redefine_rm_type.v1.0.0.adls
+++ b/ADL2-reference/validity/specialisation/openEHR-EHR-OBSERVATION.VCORMT_redefine_rm_type.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-OBSERVATION.VCORMT_redefine_rm_type.v1.0.0
 
 specialize

--- a/ADL2-reference/validity/specialisation/openEHR-EHR-OBSERVATION.VDIFP_invalid_path.v1.0.0.adls
+++ b/ADL2-reference/validity/specialisation/openEHR-EHR-OBSERVATION.VDIFP_invalid_path.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-OBSERVATION.VDIFP_invalid_path.v1.0.0
 
 specialize

--- a/ADL2-reference/validity/specialisation/openEHR-EHR-OBSERVATION.VDIFP_path_not_in_parent.v1.0.0.adls
+++ b/ADL2-reference/validity/specialisation/openEHR-EHR-OBSERVATION.VDIFP_path_not_in_parent.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-OBSERVATION.VDIFP_path_not_in_parent.v1.0.0
 
 specialize

--- a/ADL2-reference/validity/specialisation/openEHR-EHR-OBSERVATION.VPOV_redef_ac_code_node_to_local_codes.v1.0.0.adls
+++ b/ADL2-reference/validity/specialisation/openEHR-EHR-OBSERVATION.VPOV_redef_ac_code_node_to_local_codes.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-OBSERVATION.VPOV_redef_ac_code_node_to_local_codes.v1.0.0
 
 specialize

--- a/ADL2-reference/validity/specialisation/openEHR-EHR-OBSERVATION.VSANCC_redefine_cardinality.v1.0.0.adls
+++ b/ADL2-reference/validity/specialisation/openEHR-EHR-OBSERVATION.VSANCC_redefine_cardinality.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-OBSERVATION.VSANCC_redefine_cardinality.v1.0.0
 
 specialize

--- a/ADL2-reference/validity/specialisation/openEHR-EHR-OBSERVATION.VSANCE_redefine_existence.v1.0.0.adls
+++ b/ADL2-reference/validity/specialisation/openEHR-EHR-OBSERVATION.VSANCE_redefine_existence.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-OBSERVATION.VSANCE_redefine_existence.v1.0.0
 
 specialize

--- a/ADL2-reference/validity/specialisation/openEHR-EHR-OBSERVATION.VSONCO_redefine_occurrences.v1.0.0.adls
+++ b/ADL2-reference/validity/specialisation/openEHR-EHR-OBSERVATION.VSONCO_redefine_occurrences.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-OBSERVATION.VSONCO_redefine_occurrences.v1.0.0
 
 specialize

--- a/ADL2-reference/validity/specialisation/openEHR-EHR-OBSERVATION.VSONIN_override_obj_not_in_parent.v1.0.0.adls
+++ b/ADL2-reference/validity/specialisation/openEHR-EHR-OBSERVATION.VSONIN_override_obj_not_in_parent.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-OBSERVATION.VSONIN_override_obj_not_in_parent.v1.0.0
 
 specialize

--- a/ADL2-reference/validity/specialisation/openEHR-EHR-OBSERVATION.VSSM_added_nodes_ordered.v1.0.0.adls
+++ b/ADL2-reference/validity/specialisation/openEHR-EHR-OBSERVATION.VSSM_added_nodes_ordered.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-OBSERVATION.VSSM_added_nodes_ordered.v1.0.0
 
 specialize
@@ -30,18 +30,18 @@ definition
 			after [id1000]
 			ELEMENT[id0.1] matches {	-- Text field 2
 				value matches {
-					DV_TEXT[id0.1] 	-- Text field 2
+					DV_TEXT[id0.4] 	-- Text field 2
 				}
 			}
 			ELEMENT[id0.2] matches {	-- Quantity 2
 				value matches {
-					DV_QUANTITY[id0.2] 	-- Quantity 2
+					DV_QUANTITY[id0.5] 	-- Quantity 2
 				}
 			}
 			before [id8]
 			ELEMENT[id0.3] matches {	-- Text field 3
 				value matches {
-					DV_TEXT[id0.3] 	-- Text field 3
+					DV_TEXT[id0.6] 	-- Text field 3
 				}
 			}
 		}

--- a/ADL2-reference/validity/specialisation/openEHR-EHR-OBSERVATION.redefine_local_code_list.v1.0.0.adls
+++ b/ADL2-reference/validity/specialisation/openEHR-EHR-OBSERVATION.redefine_local_code_list.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=2.0.5; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-OBSERVATION.redefine_local_code_list.v1.0.0
 
 specialize

--- a/ADL2-reference/validity/specialisation/openEHR-EHR-OBSERVATION.spec_test_obs-VACSD_wrong_concept_spec_level.adls
+++ b/ADL2-reference/validity/specialisation/openEHR-EHR-OBSERVATION.spec_test_obs-VACSD_wrong_concept_spec_level.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-OBSERVATION.VACSD_wrong_concept_spec_level.v1.0.0
 
 specialise

--- a/ADL2-reference/validity/specialisation/openEHR-EHR-OBSERVATION.spec_test_obs.v1.0.0.adls
+++ b/ADL2-reference/validity/specialisation/openEHR-EHR-OBSERVATION.spec_test_obs.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=2.0.5; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-OBSERVATION.spec_test_obs.v1.0.0
 
 language

--- a/ADL2-reference/validity/specialisation/openEHR-EHR-OBSERVATION.spec_test_obs2.v1.0.0.adls
+++ b/ADL2-reference/validity/specialisation/openEHR-EHR-OBSERVATION.spec_test_obs2.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=2.0.5; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-OBSERVATION.spec_test_obs2.v1.0.0
 
 language

--- a/ADL2-reference/validity/specialisation/openEHR-EHR-OBSERVATION.spec_test_obs3.v2.0.0.adls
+++ b/ADL2-reference/validity/specialisation/openEHR-EHR-OBSERVATION.spec_test_obs3.v2.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=2.0.5; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-OBSERVATION.spec_test_obs3.v2.0.0
 
 language

--- a/ADL2-reference/validity/specialisation/openEHR-EHR-SECTION.VDIFP_non_matching_path.v1.0.0.adls
+++ b/ADL2-reference/validity/specialisation/openEHR-EHR-SECTION.VDIFP_non_matching_path.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-SECTION.VDIFP_non_matching_path.v1.0.0
 
 specialize

--- a/ADL2-reference/validity/specialisation/openEHR-EHR-SECTION.section_parent.v1.0.0.adls
+++ b/ADL2-reference/validity/specialisation/openEHR-EHR-SECTION.section_parent.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=2.0.5; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-SECTION.section_parent.v1.0.0
 
 language

--- a/ADL2-reference/validity/specialisation/openEHR-TEST_PKG-ENTRY.FAIL_missing_parent.v1.0.0.adls
+++ b/ADL2-reference/validity/specialisation/openEHR-TEST_PKG-ENTRY.FAIL_missing_parent.v1.0.0.adls
@@ -1,10 +1,8 @@
-archetype (adl_version=1.5)
-	openEHR-TEST_PKG-ENTRY.FAIL_missing_parent.v1
+archetype (adl_version=2.0.7; rm_release=1.0.2)
+	openEHR-TEST_PKG-ENTRY.FAIL_missing_parent.v1.0.0
 specialize
-	openEHR-TEST_PKG-ENTRY.specialisation_parent.v1
+	openEHR-TEST_PKG-ENTRY.specialisation_parent.v1.0.0
 
-concept
-	[at0000.1]
 language
 	original_language = <[ISO_639-1::en]>
 description
@@ -20,21 +18,19 @@ description
 		>
 	>
 	other_details = <
-		["regression"] = <"FAIL">
+		["regression"] = <"VASID">
 	>
 	lifecycle_state = <"draft">
 
 definition
-	ENTRY[at0000.1] matches {*}
+	ENTRY[id1.1]
 
-ontology
+terminology
 	term_definitions = <
 		["en"] = <
-			items = <
-				["at0000.1"] = <
-					text = <"">
-					description = <"">
-				>
-			>
+            ["id1.1"] = <
+                text = <" ">
+                description = <" ">
+            >
 		>
 	>

--- a/ADL2-reference/validity/specialisation/openEHR-TEST_PKG-ENTRY.FAIL_missing_parent_term.v1.0.0.adls
+++ b/ADL2-reference/validity/specialisation/openEHR-TEST_PKG-ENTRY.FAIL_missing_parent_term.v1.0.0.adls
@@ -1,7 +1,8 @@
-archetype (adl_version=1.5)
-	openEHR-TEST_PKG-ENTRY.FAIL_missing_parent_term.v1
+archetype (adl_version=2.0.7; rm_release=1.0.2)
+	openEHR-TEST_PKG-ENTRY.FAIL_missing_parent_term.v1.0.0
+
 specialize
-	openEHR-TEST_PKG-ENTRY.specialisation_parent.v1
+	openEHR-TEST_PKG-ENTRY.specialisation_parent.v1.0.0
 
 language
 	original_language = <[ISO_639-1::en]>
@@ -18,33 +19,27 @@ description
 		>
 	>
 	other_details = <
-		["regression"] = <"FAIL">
+		["regression"] = <"VASID"> -- pieterbos: parent archetype is missing. Should probably do something else
 	>
 	lifecycle_state = <"draft">
 
 definition
-	ENTRY[at0000.1] matches {
+	ENTRY[id1.1] matches {
 		value matches {
-			ELEMENT[at0001.1] matches {*}
+			ELEMENT[id2.1]
 		}
 	}
 
-ontology
+terminology
 	term_definitions = <
 		["en"] = <
-			items = <
-				["at0000"] = <
-					text = <"">
-					description = <"">
-				>
-				["at0000.1"] = <
-					text = <"">
-					description = <"">
-				>
-				["at0001.1"] = <
-					text = <"">
-					description = <"">
-				>
-			>
+            ["id1.1"] = <
+                text = <"">
+                description = <"">
+            >
+            ["id2.1"] = <
+                text = <"">
+                description = <"">
+            >
 		>
 	>

--- a/ADL2-reference/validity/specialisation/openEHR-TEST_PKG-ENTRY.VACSD_concept_code_wrong_specialisation_level.v1.0.0.adls
+++ b/ADL2-reference/validity/specialisation/openEHR-TEST_PKG-ENTRY.VACSD_concept_code_wrong_specialisation_level.v1.0.0.adls
@@ -1,5 +1,5 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
-	openEHR-TEST_PKG-ENTRY.VACSD_concept_code_wrong_specialisation_level.v1
+archetype (adl_version=2.0.7; rm_release=1.0.2)
+	openEHR-TEST_PKG-ENTRY.VACSD_concept_code_wrong_specialisation_level.v1.0.0
 
 language
 	original_language = <[ISO_639-1::en]>
@@ -17,21 +17,19 @@ description
 		>
 	>
 	other_details = <
-		["regression"] = <"VACSD">
+		["regression"] = <"VARCN">
 	>
 	lifecycle_state = <"draft">
 
 definition
-	ENTRY[id1.1] matches {*}
+	ENTRY[id1.1]
 
 terminology
 	term_definitions = <
 		["en"] = <
-			items = <
-				["id1.1"] = <
-					text = <"">
-					description = <"">
-				>
-			>
+            ["id1.1"] = <
+                text = <" ">
+                description = <" ">
+            >
 		>
 	>

--- a/ADL2-reference/validity/specialisation/openEHR-TEST_PKG-ENTRY.VTSD_ac_code_wrong_specialisation_level.v1.0.0.adls
+++ b/ADL2-reference/validity/specialisation/openEHR-TEST_PKG-ENTRY.VTSD_ac_code_wrong_specialisation_level.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-TEST_PKG-ENTRY.VTSD_ac_code_wrong_specialisation_level.v1.0.0
 
 language

--- a/ADL2-reference/validity/specialisation/openEHR-TEST_PKG-ENTRY.VTSD_at_code_wrong_specialisation_level.v1.0.0.adls
+++ b/ADL2-reference/validity/specialisation/openEHR-TEST_PKG-ENTRY.VTSD_at_code_wrong_specialisation_level.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-TEST_PKG-ENTRY.VTSD_at_code_wrong_specialisation_level.v1.0.0
 
 language

--- a/ADL2-reference/validity/structure/openEHR-EHR-EVALUATION.VCACA_invalid_cardinality.adls
+++ b/ADL2-reference/validity/structure/openEHR-EHR-EVALUATION.VCACA_invalid_cardinality.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-EVALUATION.VCACA_invalid_cardinality.v1.0.0
 
 language

--- a/ADL2-reference/validity/structure/openEHR-EHR-EVALUATION.VCARM_table.v1.0.0.adls
+++ b/ADL2-reference/validity/structure/openEHR-EHR-EVALUATION.VCARM_table.v1.0.0.adls
@@ -1,5 +1,5 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
-	openEHR-EHR-EVALUATION.VCARM_table.v1
+archetype (adl_version=2.0.6; rm_release=1.0.2)
+	openEHR-EHR-EVALUATION.VCARM_table.v1.0.0
 
 language
 	original_language = <[ISO_639-1::en]>
@@ -18,7 +18,7 @@ description
 		>
 	>
 	other_details = <
-		["regression"] = <"FAIL">
+		["regression"] = <"VCARM">
 	>
 	lifecycle_state = <"unmanaged">
 
@@ -29,7 +29,7 @@ definition
 				columns cardinality matches {3; ordered} matches {
 					CLUSTER[id3] matches {	-- aspect
 						name matches {
-							DV_CODED_TEXT
+							DV_CODED_TEXT[id4]
 						}
 					}
 				}

--- a/ADL2-reference/validity/structure/openEHR-EHR-EVALUATION.use_node_ref_to_sibling.v1.0.0.adls
+++ b/ADL2-reference/validity/structure/openEHR-EHR-EVALUATION.use_node_ref_to_sibling.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=2.0.5; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-EVALUATION.use_node_ref_to_sibling.v1.0.0
 
 language

--- a/ADL2-reference/validity/structure/openEHR-EHR-OBSERVATION.WACMCL_container_items_out_of_bounds.v1.0.0.adls
+++ b/ADL2-reference/validity/structure/openEHR-EHR-OBSERVATION.WACMCL_container_items_out_of_bounds.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=2.0.5; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-OBSERVATION.WACMCL_container_items_out_of_bounds.v1.0.0
 
 language
@@ -39,9 +39,9 @@ definition
 									}
 									CLUSTER[id8] matches {	
 										items cardinality matches {1..2} matches {
-											ELEMENT[id9] occurrences matches {1} matches {*}
-											ELEMENT[id10] occurrences matches {2..*} matches {*}
-											ELEMENT[id11] occurrences matches {0..1} matches {*}
+											ELEMENT[id9] occurrences matches {1}
+											ELEMENT[id10] occurrences matches {2..*}
+											ELEMENT[id11] occurrences matches {0..1}
 										}
 									}
 								}

--- a/ADL2-reference/validity/structure/openEHR-TEST_PKG-ENTRY.SEXLU_attribute_wrong_existence.v1.0.0.adls
+++ b/ADL2-reference/validity/structure/openEHR-TEST_PKG-ENTRY.SEXLU_attribute_wrong_existence.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.6; rm_release=1.0.2)
 	openEHR-TEST_PKG-ENTRY.SEXLU_attribute_wrong_existence.v1.0.0
 
 language
@@ -22,7 +22,7 @@ description
 
 definition
 	ENTRY[id1] matches {
-		value existence matches {1..2} matches {*}
+		value existence matches {1..2}
 	}
 
 terminology

--- a/ADL2-reference/validity/structure/openEHR-TEST_PKG-ENTRY.VACMC_occurrences_too_big.v1.0.0.adls
+++ b/ADL2-reference/validity/structure/openEHR-TEST_PKG-ENTRY.VACMC_occurrences_too_big.v1.0.0.adls
@@ -1,5 +1,5 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
-	openEHR-TEST_PKG-ENTRY.VACMC_occurrences_too_big.v1
+archetype (adl_version=2.0.7; rm_release=1.0.2)
+	openEHR-TEST_PKG-ENTRY.VACMC_occurrences_too_big.v1.0.0
 
 language
 	original_language = <[ISO_639-1::en]>
@@ -23,7 +23,7 @@ description
 definition
 	ENTRY[id1] matches {
 		element_attr_2 cardinality matches {0..1} matches {
-			ELEMENT[id2] occurrences matches {1..2} matches {*}
+			ELEMENT[id2] occurrences matches {1..2}
 		}
 	}
 
@@ -31,7 +31,7 @@ terminology
 	term_definitions = <
 		["en"] = <
 			["id1"] = <
-				text = <"">
+				text = <" ">
 				description = <"">
 			>
 			["id2"] = <

--- a/ADL2-reference/validity/structure/openEHR-TEST_PKG-ENTRY.VACSO_attribute_wrong_cardinality.v1.0.0.adls
+++ b/ADL2-reference/validity/structure/openEHR-TEST_PKG-ENTRY.VACSO_attribute_wrong_cardinality.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-TEST_PKG-ENTRY.VACSO_attribute_wrong_cardinality.v1.0.0
 
 language
@@ -24,22 +24,20 @@ description
 definition
 	ENTRY[id1] matches {
 		element_attr matches {
-			ELEMENT[id2] occurrences matches {1..2} matches {*}
+			ELEMENT[id2] occurrences matches {1..2}
 		}
 	}
 
 terminology
 	term_definitions = <
 		["en"] = <
-			items = <
-				["id1"] = <
-					text = <"">
-					description = <"">
-				>
-				["id2"] = <
-					text = <"">
-					description = <"">
-				>
-			>
+            ["id1"] = <
+                text = <" ">
+                description = <" ">
+            >
+            ["id2"] = <
+                text = <" ">
+                description = <" ">
+            >
 		>
 	>

--- a/ADL2-reference/validity/structure/openEHR-TEST_PKG-ENTRY.VATDA_at_code_assumed_code_not_in_list.v1.0.0.adls
+++ b/ADL2-reference/validity/structure/openEHR-TEST_PKG-ENTRY.VATDA_at_code_assumed_code_not_in_list.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-TEST_PKG-ENTRY.VATDA_at_code_assumed_code_not_in_list.v1.0.0
 
 language

--- a/ADL2-reference/validity/structure/openEHR-TEST_PKG-ENTRY.VUNP_attribute_use_node_missing_path.v1.0.0.adls
+++ b/ADL2-reference/validity/structure/openEHR-TEST_PKG-ENTRY.VUNP_attribute_use_node_missing_path.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=2.0.5; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-TEST_PKG-ENTRY.VUNP_attribute_use_node_missing_path.v1.0.0
 
 language

--- a/ADL2-reference/validity/structure/openEHR-TEST_PKG-ENTRY.VUNP_attribute_use_node_path_isnt_object.v1.0.0.adls
+++ b/ADL2-reference/validity/structure/openEHR-TEST_PKG-ENTRY.VUNP_attribute_use_node_path_isnt_object.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=2.0.5; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-TEST_PKG-ENTRY.VUNP_attribute_use_node_path_isnt_object.v1.0.0
 
 language

--- a/ADL2-reference/validity/structure/openEHR-TEST_PKG-ENTRY.attribute_occurrences_too_small.v1.0.0.adls
+++ b/ADL2-reference/validity/structure/openEHR-TEST_PKG-ENTRY.attribute_occurrences_too_small.v1.0.0.adls
@@ -1,5 +1,5 @@
-archetype (adl_version=2.0.5; rm_release=1.0.2)
-	openEHR-TEST_PKG-ENTRY.attribute_occurrences_too_small.v1.0.0
+archetype (adl_version=2.0.7; rm_release=1.0.2)
+	openEHR-TEST_PKG-ADMIN_ENTRY.attribute_occurrences_too_small.v1.0.0
 
 language
 	original_language = <[ISO_639-1::en]>
@@ -22,9 +22,13 @@ description
 	copyright = <"copyright (c) 2008 The openEHR Foundation">
 
 definition
-	ENTRY[id1] matches {	-- 
-		element_attr_2 cardinality matches {2..3; ordered} matches {
-			ELEMENT[id2] occurrences matches {1..2} 	-- 
+	ADMIN_ENTRY[id1] matches {	--
+		data matches {
+		    ITEM_LIST[id3] matches {
+		        items cardinality matches {2..3; ordered} matches {
+		            ELEMENT[id2] occurrences matches {1..2} 	--
+                }
+		    }
 		}
 	}
 
@@ -36,6 +40,10 @@ terminology
 				description = <"">
 			>
 			["id2"] = <
+				text = <"">
+				description = <"">
+			>
+			["id3"] = <
 				text = <"">
 				description = <"">
 			>

--- a/ADL2-reference/validity/templates/openEHR-EHR-COMPOSITION.t_non_existent_ext_ref.v1.0.0.adls
+++ b/ADL2-reference/validity/templates/openEHR-EHR-COMPOSITION.t_non_existent_ext_ref.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-COMPOSITION.t_non_existent_ext_ref.v1.0.0
 
 language

--- a/ADL2-reference/validity/terminology/openEHR-EHR-EVALUATION.VPOV_code_list_constrained.v1.0.0.adls
+++ b/ADL2-reference/validity/terminology/openEHR-EHR-EVALUATION.VPOV_code_list_constrained.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-EVALUATION.VPOV_code_list_constrained.v1.0.0
 
 specialize

--- a/ADL2-reference/validity/terminology/openEHR-EHR-OBSERVATION.VTSD_terminology_code_from_higher_level.v1.0.0.adls
+++ b/ADL2-reference/validity/terminology/openEHR-EHR-OBSERVATION.VTSD_terminology_code_from_higher_level.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-OBSERVATION.VTSD_terminology_code_from_higher_level.v1.0.0
 
 specialize

--- a/ADL2-reference/validity/terminology/openEHR-EHR-OBSERVATION.VTSD_terminology_code_from_lower_level.v1.0.0.adls
+++ b/ADL2-reference/validity/terminology/openEHR-EHR-OBSERVATION.VTSD_terminology_code_from_lower_level.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-EHR-OBSERVATION.VTSD_terminology_code_from_lower_level.v1.0.0
 
 specialize

--- a/ADL2-reference/validity/terminology/openEHR-EHR-OBSERVATION.VTTBK_term_bindings_bad_paths.adls
+++ b/ADL2-reference/validity/terminology/openEHR-EHR-OBSERVATION.VTTBK_term_bindings_bad_paths.adls
@@ -1,5 +1,5 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
-	openEHR-EHR-OBSERVATION.VTBK_term_bindings_paths.v1
+archetype (adl_version=2.0.7; rm_release=1.0.2)
+	openEHR-EHR-OBSERVATION.VTTBK_term_bindings_paths.v1.0.0
 
 language
 	original_language = <[ISO_639-1::en]>
@@ -11,7 +11,7 @@ description
 	details = <
 		["en"] = <
 			language = <[ISO_639-1::en]>
-			purpose = <"Test VTBK validity check for paths mentioned in term_bindings.">
+			purpose = <"Test VTTBK validity check for paths mentioned in term_bindings.">
 		>
 	>
 	other_details = <
@@ -27,7 +27,7 @@ definition
 						data matches {
 							ITEM_LIST[id2] matches {
 								items cardinality matches {1..6; ordered} matches {
-									ELEMENT[id5] occurrences matches {0..1} matches {*}
+									ELEMENT[id5] occurrences matches {0..1}
 								}
 							}
 						}
@@ -65,10 +65,8 @@ terminology
 	>
 	term_bindings = <
 		["LNC205"] = <
-			items = <
-				["/data[id3]/events[id4]/data[id2]/items[id5]"] = <http://LNC205.org/id/9272-6>
-				["/data[id3]/events[id7]/data/items[id5]"] = <http://LNC205.org/id/9271-8>
-				["junk_garbage"] = <http://LNC205.org/id/9271-8>
-			>
+            ["/data[id3]/events[id4]/data[id2]/items[id5]"] = <http://LNC205.org/id/9272-6>
+            ["/data[id3]/events[id7]/data/items[id5]"] = <http://LNC205.org/id/9271-8>
+            ["junk_garbage"] = <http://LNC205.org/id/9271-8>
 		>
 	>

--- a/ADL2-reference/validity/terminology/openEHR-TEST_PKG-ENTRY.FAIL_terminology_empty.v1.0.0.adls
+++ b/ADL2-reference/validity/terminology/openEHR-TEST_PKG-ENTRY.FAIL_terminology_empty.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-TEST_PKG-ENTRY.FAIL_terminology_empty.v1.0.0
 
 language
@@ -22,6 +22,6 @@ description
 	lifecycle_state = <"draft">
 
 definition
-	ENTRY[id1] matches {*}
+	ENTRY[id1]
 
 terminology

--- a/ADL2-reference/validity/terminology/openEHR-TEST_PKG-ENTRY.FAIL_terminology_term_definitions_missing.v1.0.0.adls
+++ b/ADL2-reference/validity/terminology/openEHR-TEST_PKG-ENTRY.FAIL_terminology_term_definitions_missing.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.6; rm_release=1.0.2)
 	openEHR-TEST_PKG-ENTRY.FAIL_terminology_term_definitions_missing.v1.0.0
 
 language
@@ -22,6 +22,6 @@ description
 	lifecycle_state = <"draft">
 
 definition
-	ENTRY[id1] matches {*}
+	ENTRY[id1]
 
 terminology

--- a/ADL2-reference/validity/terminology/openEHR-TEST_PKG-ENTRY.VOKU_ac_code_duplicated_in_terminology.v1.0.0.adls
+++ b/ADL2-reference/validity/terminology/openEHR-TEST_PKG-ENTRY.VOKU_ac_code_duplicated_in_terminology.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-TEST_PKG-ENTRY.VOKU_ac_code_duplicated_in_terminology.v1.0.0
 
 language

--- a/ADL2-reference/validity/terminology/openEHR-TEST_PKG-ENTRY.VOKU_at_code_duplicated_in_terminology.v1.0.0.adls
+++ b/ADL2-reference/validity/terminology/openEHR-TEST_PKG-ENTRY.VOKU_at_code_duplicated_in_terminology.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-TEST_PKG-ENTRY.VOKU_at_code_duplicated_in_terminology.v1.0.0
 
 language
@@ -24,26 +24,24 @@ description
 definition
 	ENTRY[id1] matches {
 		element_attr matches {
-			ELEMENT[id2] matches {*}
+			ELEMENT[id2]
 		}
 	}
 
 terminology
 	term_definitions = <
 		["en"] = <
-			items = <
-				["id1"] = <
-					text = <"">
-					description = <"">
-				>
-				["id2"] = <
-					text = <"">
-					description = <"">
-				>
-				["id2"] = <
-					text = <"">
-					description = <"">
-				>
-			>
+            ["id1"] = <
+                text = <"">
+                description = <"">
+            >
+            ["id2"] = <
+                text = <"">
+                description = <"">
+            >
+            ["id2"] = <
+                text = <"">
+                description = <"">
+            >
 		>
 	>

--- a/ADL2-reference/validity/terminology/openEHR-TEST_PKG-ENTRY.VTVSUQ_at_code_duplicated_in_internal_codes.v1.0.0.adls
+++ b/ADL2-reference/validity/terminology/openEHR-TEST_PKG-ENTRY.VTVSUQ_at_code_duplicated_in_internal_codes.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=1.5.1; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-TEST_PKG-ENTRY.VTVSUQ_at_code_duplicated_in_internal_codes.v1.0.0
 
 language

--- a/ADL2-reference/validity/terminology/openEHR-TEST_PKG-ENTRY.WOUC_ac_code_unused.v1.0.0.adls
+++ b/ADL2-reference/validity/terminology/openEHR-TEST_PKG-ENTRY.WOUC_ac_code_unused.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=2.0.5; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-TEST_PKG-ENTRY.WOUC_ac_code_unused.v1.0.0
 
 language

--- a/ADL2-reference/validity/terminology/openEHR-TEST_PKG-ENTRY.WOUC_at_code_unused.v1.0.0.adls
+++ b/ADL2-reference/validity/terminology/openEHR-TEST_PKG-ENTRY.WOUC_at_code_unused.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=2.0.5; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openEHR-TEST_PKG-ENTRY.WOUC_at_code_unused.v1.0.0
 
 language

--- a/ADL2-reference/validity/terminology/openehr-TEST_PKG-SOME_TYPE.VETDF_wrong_property_code.v1.0.0.adls
+++ b/ADL2-reference/validity/terminology/openehr-TEST_PKG-SOME_TYPE.VETDF_wrong_property_code.v1.0.0.adls
@@ -1,4 +1,4 @@
-archetype (adl_version=2.0.5; rm_release=1.0.2)
+archetype (adl_version=2.0.7; rm_release=1.0.2)
 	openehr-TEST_PKG-SOME_TYPE.VETDF_wrong_property_code.v1.0.0
 
 language


### PR DESCRIPTION
Currently implementing validation, phase 1 done except for some warnings and phase 2 about 50%. Found lots of small issues in the adl library, fixed them here. 

Main errors:

1. Old format (1.5 and 1.5.1) files that no longer parse
2. ENTRY[id1] matches {*} -> ENTRY[id1]
3. items = < in terminology to new syntax
4. Some archetypes that tested one error also had other problems that hid the first problem.
5. Updated ADL version number to 2.0.7 since it's now valid ADL 2.0.7
6. Some minor syntax errors like extra '>' or '}' characters

Fixes https://github.com/openEHR/adl-archetypes/issues/9
Fixes https://github.com/openEHR/adl-archetypes/issues/3